### PR TITLE
OAS.json was invalid due to duplicate keys, this will fix that.

### DIFF
--- a/definition/oas/v2023.01/oas.json
+++ b/definition/oas/v2023.01/oas.json
@@ -1017,30 +1017,30 @@
                     }
                 ]
             },
-            "Edm.Geography": {
-                "$ref": "#/components/schemas/Edm.Geography"
-            },
-            "Edm.GeographyPoint": {
-                "$ref": "#/components/schemas/Edm.GeographyPoint"
-            },
-            "Edm.GeographyLineString": {
-                "$ref": "#/components/schemas/Edm.GeographyLineString"
-            },
-            "Edm.GeographyPolygon": {
-                "$ref": "#/components/schemas/Edm.GeographyPolygon"
-            },
-            "Edm.GeographyMultiPoint": {
-                "$ref": "#/components/schemas/Edm.GeographyMultiPoint"
-            },
-            "Edm.GeographyMultiLineString": {
-                "$ref": "#/components/schemas/Edm.GeographyMultiLineString"
-            },
-            "Edm.GeographyMultiPolygon": {
-                "$ref": "#/components/schemas/Edm.GeographyMultiPolygon"
-            },
-            "Edm.GeographyCollection": {
-                "$ref": "#/components/schemas/Edm.GeographyCollection"
-            },
+            #"Edm.Geography": {
+            #    "$ref": "#/components/schemas/Edm.Geography"
+            #},
+            #"Edm.GeographyPoint": {
+            #    "$ref": "#/components/schemas/Edm.GeographyPoint"
+            #},
+            #"Edm.GeographyLineString": {
+            #    "$ref": "#/components/schemas/Edm.GeographyLineString"
+            #},
+            #"Edm.GeographyPolygon": {
+            #    "$ref": "#/components/schemas/Edm.GeographyPolygon"
+            #},
+            #"Edm.GeographyMultiPoint": {
+            #    "$ref": "#/components/schemas/Edm.GeographyMultiPoint"
+            #},
+            #"Edm.GeographyMultiLineString": {
+            #    "$ref": "#/components/schemas/Edm.GeographyMultiLineString"
+            #},
+            #"Edm.GeographyMultiPolygon": {
+            #    "$ref": "#/components/schemas/Edm.GeographyMultiPolygon"
+            #},
+            #"Edm.GeographyCollection": {
+            #    "$ref": "#/components/schemas/Edm.GeographyCollection"
+            #},
             "Edm.Geography": {
                 "type": "object",
                 "oneOf": [

--- a/definition/oas/v2023.01/oas.json
+++ b/definition/oas/v2023.01/oas.json
@@ -1017,30 +1017,6 @@
                     }
                 ]
             },
-            #"Edm.Geography": {
-            #    "$ref": "#/components/schemas/Edm.Geography"
-            #},
-            #"Edm.GeographyPoint": {
-            #    "$ref": "#/components/schemas/Edm.GeographyPoint"
-            #},
-            #"Edm.GeographyLineString": {
-            #    "$ref": "#/components/schemas/Edm.GeographyLineString"
-            #},
-            #"Edm.GeographyPolygon": {
-            #    "$ref": "#/components/schemas/Edm.GeographyPolygon"
-            #},
-            #"Edm.GeographyMultiPoint": {
-            #    "$ref": "#/components/schemas/Edm.GeographyMultiPoint"
-            #},
-            #"Edm.GeographyMultiLineString": {
-            #    "$ref": "#/components/schemas/Edm.GeographyMultiLineString"
-            #},
-            #"Edm.GeographyMultiPolygon": {
-            #    "$ref": "#/components/schemas/Edm.GeographyMultiPolygon"
-            #},
-            #"Edm.GeographyCollection": {
-            #    "$ref": "#/components/schemas/Edm.GeographyCollection"
-            #},
             "Edm.Geography": {
                 "type": "object",
                 "oneOf": [


### PR DESCRIPTION
the `definition\oas\v2023.01\oas.json` file had duplicated keys. making the JSON invalid and as a result the OpenAPI definition.
this was preventing use of the file as a source of truth.

This PR addresses the duplication. 

as a Suggestion to prevent this sort of thing happenign: Stop relying on generated definitions, and make the actual definitions 'by hand' using a generated file as a starting point. 

 - Lawri van Buël